### PR TITLE
fix: use Avatar in Account

### DIFF
--- a/ui/src/pages/Account/Account.tsx
+++ b/ui/src/pages/Account/Account.tsx
@@ -2,8 +2,7 @@ import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import AccountCircle from '@mui/icons-material/AccountCircle';
-import { Avatar, Button, Chip, Divider, Stack, Typography } from '@mui/material';
+import { Avatar, Button, Chip, Divider, Stack } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 
 import { useSnackbar } from 'notistack';

--- a/ui/src/pages/Account/Account.tsx
+++ b/ui/src/pages/Account/Account.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import AccountCircle from '@mui/icons-material/AccountCircle';
-import { Button, Chip, Divider, Stack, Typography } from '@mui/material';
+import { Avatar, Button, Chip, Divider, Stack, Typography } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 
 import { useSnackbar } from 'notistack';
@@ -81,12 +81,10 @@ function Account() {
           alignItems="center"
           pt="4vh"
           disableEqualOverflow
+          direction="column"
         >
           <Grid>
-            <AccountCircle fontSize="large" />
-          </Grid>
-          <Grid>
-            <Typography variant="h4">{user.displayName}</Typography>
+            <Avatar sx={{ width: 80, height: 80, fontSize: 40 }}>{user.displayName?.at(0)}</Avatar>
           </Grid>
         </Grid>
         <Divider sx={{ py: '4vh' }}>


### PR DESCRIPTION
As a workaround to the signup displayName bug, we can use the avatar instead.

Closes #33 